### PR TITLE
Added usage for FAN2

### DIFF
--- a/ANYCUBIC_Kossel_Plus_Beta2/pins_RAMPS.h
+++ b/ANYCUBIC_Kossel_Plus_Beta2/pins_RAMPS.h
@@ -151,7 +151,7 @@
 //
 // Heaters / Fans
 //
-#define FAN2_PIN     -1
+#define FAN2_PIN     44
 
 #ifndef MOSFET_D_PIN
   #define MOSFET_D_PIN  -1


### PR DESCRIPTION
To use the second fan on the print head, pin 44 has to be defined as FAN2.